### PR TITLE
Update utils.py

### DIFF
--- a/django_pandas/utils.py
+++ b/django_pandas/utils.py
@@ -44,7 +44,7 @@ def replace_pk(model):
     base_cache_key = get_base_cache_key(model)
 
     def get_cache_key_from_pk(pk):
-        return None if pk is None else base_cache_key % str(pk)
+        return None if pk is None else base_cache_key % str(int(pk))
 
     def inner(pk_series):
         pk_series = pk_series.astype(object).where(pk_series.notnull(), None)


### PR DESCRIPTION
Ensure that the cache key pk (if used) is always converted to an INT format.

This addresses a bug that occurs when a queryset is loaded into a dataframe. Specifically, if the queryset includes a foreign key with nullable fields and a mix of instances with null and non-null related fields, pandas assigns the dtype of the primary key (pk) column as object. Consequently, pk values are automatically converted to floats because a pandas integer Series cannot contain None.

To avoid this, we must explicitly reconvert the pk column to INT before using it as a cache key.

Without this step, as of now, the dataframe ends up with None for every row in such cases.

[Using pandas 2.2.2]

